### PR TITLE
Fixed push notifications for security system.

### DIFF
--- a/src/securitySystemPlatformAccessory.ts
+++ b/src/securitySystemPlatformAccessory.ts
@@ -74,9 +74,21 @@ export class SecuritySystemPlatformAccessory {
   ): void {
     const homekitGuardMode = this.convertStatusCodeToHomekit(guardMode);
     if (homekitGuardMode) {
+      this.platform.log.debug(
+        'Received StationGuardModePushNotification - guardmode ' +
+          guardMode +
+          ' homekitGuardMode ' +
+          homekitGuardMode,
+      );
       this.service
         .getCharacteristic(
           this.platform.Characteristic.SecuritySystemCurrentState,
+        )
+        .updateValue(homekitGuardMode);
+
+      this.service
+        .getCharacteristic(
+          this.platform.Characteristic.SecuritySystemTargetState,
         )
         .updateValue(homekitGuardMode);
     }


### PR DESCRIPTION
Didn't know SecuritySystemTargetState had to be set when using updateValue for Security system service. Eufy home mode (value =1) doesn't trigger push notification. I have created an issue in eufy-security-client repo (https://github.com/bropat/eufy-security-client/issues/14).