### PR TITLE
Added on/off for regular eufy cams. Tested on Eufycam 2C.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The doorbell support is still a work in progress and needs more testing. Please 
 | Eufy Device   | Supported Functions             | HomeKit                               |
 | ------------- | ------------------------------- | ------------------------------------- |
 | HomeBase      | Can change guard mode           | Shows as a security system in HomeKit |
-| Camera        | Reports motion                  | Shows as Motion Sensor                |
+| Camera        | Reports motion On/Off           | Shows as Motion Sensor                |
 | Motion Sensor | Reports motion                  | Shows as Motion Sensor                |
 | Entry Sensor  | Open/Close detection            | Shows as Contact Sensor               |
 | Doorbell      | Livestream, Ringing Notification | Shows as Doorbell                     |

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -327,4 +327,8 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
       }, this.eufyConfig.pollingIntervalMinutes * 60 * 1000);
     }
   }
+
+  public getStationById(id: string){
+    return this.eufyClient.getStation(id);
+  }
 }


### PR DESCRIPTION
Added on/off for regular EufyCams. Tested on EufyCam 2C. Not thought through if we should just pass the Station or call the platform and fetch the station. With multiple stations the use of this.eufyDevice.getStationSerial() would be required.